### PR TITLE
Fix attribute loading and word count errors

### DIFF
--- a/src/renderer/components/AttributesManager.js
+++ b/src/renderer/components/AttributesManager.js
@@ -53,6 +53,11 @@ class AttributesManager {
      * Ensure that attribute files exist for all content types
      */
     async ensureAttributeFiles() {
+        if (!this.electronAPI) {
+            console.warn('electronAPI not available, cannot ensure attribute files');
+            return;
+        }
+
         if (!this.currentProject) return;
 
         for (const contentType of Object.keys(this.defaultTemplates)) {
@@ -74,9 +79,16 @@ class AttributesManager {
      * Load attributes for a specific content type
      */
     async loadAttributes(contentType) {
-        if (!this.currentProject) return this.defaultTemplates[contentType] || {};
+        if (!this.electronAPI) {
+            console.warn('electronAPI not available, using default attributes');
+            return this.defaultTemplates[contentType] || {};
+        }
 
-        // Check cache first
+        if (!this.currentProject) {
+            console.warn('No current project set, using default attributes');
+            return this.defaultTemplates[contentType] || {};
+        }
+
         const cacheKey = `${this.currentProject}_${contentType}`;
         if (this.attributeCache.has(cacheKey)) {
             return this.attributeCache.get(cacheKey);
@@ -100,6 +112,11 @@ class AttributesManager {
      * Save attributes for a specific content type
      */
     async saveAttributes(contentType, attributes) {
+        if (!this.electronAPI) {
+            console.warn('electronAPI not available, cannot save attributes');
+            return false;
+        }
+
         if (!this.currentProject) return false;
 
         try {

--- a/src/renderer/components/Editor/StatusBar.js
+++ b/src/renderer/components/Editor/StatusBar.js
@@ -11,7 +11,8 @@ export function updateWordCount() {
     const editorContent = document.getElementById('editor-content');
     if (!editorContent) return;
 
-    const text = editorContent.value;
+    // Handle both input elements and contentEditable elements
+    const text = editorContent.value || editorContent.textContent || editorContent.innerText || '';
     const wordCount = text.trim() === '' ? 0 : text.trim().split(/\s+/).length;
     const charCount = text.length;
 


### PR DESCRIPTION
Fix `electronAPI` and `trim()` errors by adding null checks and improving text extraction.

This PR ensures graceful degradation when Electron APIs are unavailable and provides robust word counting for `contentEditable` elements, preventing `TypeError` crashes.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-b97edf0b-e546-4f0d-bcc7-346017fc345a) · [Cursor](https://cursor.com/background-agent?bcId=bc-b97edf0b-e546-4f0d-bcc7-346017fc345a)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)